### PR TITLE
Add compatibility with older Guava versions

### DIFF
--- a/src/main/java/net/kyori/text/AbstractComponent.java
+++ b/src/main/java/net/kyori/text/AbstractComponent.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.text;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
@@ -180,22 +179,16 @@ public abstract class AbstractComponent implements Component {
   @Nonnull
   @Override
   public String toString() {
-    final MoreObjects.ToStringHelper builder = MoreObjects.toStringHelper(this);
-    this.populateToString(builder);
-    builder
-      .add("children", this.children)
-      .add("color", this.color)
-      .add("obfuscated", this.obfuscated)
-      .add("bold", this.bold)
-      .add("strikethrough", this.strikethrough)
-      .add("underlined", this.underlined)
-      .add("italic", this.italic)
-      .add("clickEvent", this.clickEvent)
-      .add("hoverEvent", this.hoverEvent)
-      .add("insertion", this.insertion);
-    return builder.toString();
-  }
-
-  protected void populateToString(@Nonnull final MoreObjects.ToStringHelper builder) {
+    return "AbstractComponent(" +
+        "children=" + children() + ", " +
+        "color=" + color() + ", " +
+        "obfuscated=" + decoration(TextDecoration.OBFUSCATED) + ", " +
+        "bold=" + decoration(TextDecoration.BOLD) + ", " +
+        "strikethrough=" + decoration(TextDecoration.STRIKETHROUGH) + ", " +
+        "underlined=" + decoration(TextDecoration.UNDERLINE) + ", " +
+        "italic=" + decoration(TextDecoration.ITALIC) + ", " +
+        "clickEvent=" + clickEvent() + ", " +
+        "hoverEvent=" + hoverEvent() + ", " +
+        "insertion=" + insertion() + ")";
   }
 }

--- a/src/main/java/net/kyori/text/KeybindComponent.java
+++ b/src/main/java/net/kyori/text/KeybindComponent.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.text;
 
-import com.google.common.base.MoreObjects;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
@@ -215,9 +214,21 @@ public class KeybindComponent extends AbstractBuildableComponent<KeybindComponen
     return Objects.hash(super.hashCode(), this.keybind);
   }
 
+  @Nonnull
   @Override
-  protected void populateToString(@Nonnull final MoreObjects.ToStringHelper builder) {
-    builder.add("keybind", this.keybind);
+  public String toString() {
+    return "KeybindComponent(" +
+        "keybind=" + keybind() + ", " +
+        "children=" + children() + ", " +
+        "color=" + color() + ", " +
+        "obfuscated=" + decoration(TextDecoration.OBFUSCATED) + ", " +
+        "bold=" + decoration(TextDecoration.BOLD) + ", " +
+        "strikethrough=" + decoration(TextDecoration.STRIKETHROUGH) + ", " +
+        "underlined=" + decoration(TextDecoration.UNDERLINE) + ", " +
+        "italic=" + decoration(TextDecoration.ITALIC) + ", " +
+        "clickEvent=" + clickEvent() + ", " +
+        "hoverEvent=" + hoverEvent() + ", " +
+        "insertion=" + insertion() + ")";
   }
 
   @Nonnull

--- a/src/main/java/net/kyori/text/LegacyComponent.java
+++ b/src/main/java/net/kyori/text/LegacyComponent.java
@@ -24,7 +24,6 @@
 package net.kyori.text;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Streams;
 import net.kyori.text.format.TextColor;
 import net.kyori.text.format.TextDecoration;
 import net.kyori.text.format.TextFormat;
@@ -34,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,8 +41,21 @@ import javax.annotation.Nullable;
 public final class LegacyComponent {
 
   @VisibleForTesting static final char CHARACTER = '\u00A7';
-  private static final TextFormat[] FORMATS = Streams.concat(Arrays.stream(TextColor.values()), Arrays.stream(TextDecoration.values()), Stream.of(Reset.INSTANCE)).toArray(TextFormat[]::new);
-  private static final String FORMAT_LOOKUP = Arrays.stream(FORMATS).map(format -> String.valueOf(format.legacy())).collect(Collectors.joining());
+  private static final TextFormat[] FORMATS;
+  private static final String FORMAT_LOOKUP;
+
+  static {
+    TextColor[] colors = TextColor.values();
+    TextDecoration[] decorations = TextDecoration.values();
+
+    FORMATS = new TextFormat[colors.length + decorations.length + 1];
+    int c = 0;
+    for(final TextColor color : colors) FORMATS[c++] = color;
+    for(final TextDecoration decoration : decorations) FORMATS[c++] = decoration;
+    FORMATS[c] = Reset.INSTANCE;
+
+    FORMAT_LOOKUP = Arrays.stream(FORMATS).map(format -> String.valueOf(format.legacy())).collect(Collectors.joining());
+  }
 
   private LegacyComponent() {
   }

--- a/src/main/java/net/kyori/text/ScoreComponent.java
+++ b/src/main/java/net/kyori/text/ScoreComponent.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.text;
 
-import com.google.common.base.MoreObjects;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
@@ -290,12 +289,23 @@ public class ScoreComponent extends AbstractBuildableComponent<ScoreComponent, S
     return Objects.hash(super.hashCode(), this.name, this.objective, this.value);
   }
 
+  @Nonnull
   @Override
-  protected void populateToString(@Nonnull final MoreObjects.ToStringHelper builder) {
-    builder
-      .add("name", this.name)
-      .add("objective", this.objective)
-      .add("value", this.value);
+  public String toString() {
+    return "ScoreComponent(" +
+        "name=" + name() + ", " +
+        "objective=" + objective() + ", " +
+        "value=" + value() + ", " +
+        "children=" + children() + ", " +
+        "color=" + color() + ", " +
+        "obfuscated=" + decoration(TextDecoration.OBFUSCATED) + ", " +
+        "bold=" + decoration(TextDecoration.BOLD) + ", " +
+        "strikethrough=" + decoration(TextDecoration.STRIKETHROUGH) + ", " +
+        "underlined=" + decoration(TextDecoration.UNDERLINE) + ", " +
+        "italic=" + decoration(TextDecoration.ITALIC) + ", " +
+        "clickEvent=" + clickEvent() + ", " +
+        "hoverEvent=" + hoverEvent() + ", " +
+        "insertion=" + insertion() + ")";
   }
 
   @Nonnull

--- a/src/main/java/net/kyori/text/SelectorComponent.java
+++ b/src/main/java/net/kyori/text/SelectorComponent.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.text;
 
-import com.google.common.base.MoreObjects;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
@@ -218,9 +217,21 @@ public class SelectorComponent extends AbstractBuildableComponent<SelectorCompon
     return Objects.hash(super.hashCode(), this.pattern);
   }
 
+  @Nonnull
   @Override
-  protected void populateToString(@Nonnull final MoreObjects.ToStringHelper builder) {
-    builder.add("pattern", this.pattern);
+  public String toString() {
+    return "SelectorComponent(" +
+        "pattern=" + pattern() + ", " +
+        "children=" + children() + ", " +
+        "color=" + color() + ", " +
+        "obfuscated=" + decoration(TextDecoration.OBFUSCATED) + ", " +
+        "bold=" + decoration(TextDecoration.BOLD) + ", " +
+        "strikethrough=" + decoration(TextDecoration.STRIKETHROUGH) + ", " +
+        "underlined=" + decoration(TextDecoration.UNDERLINE) + ", " +
+        "italic=" + decoration(TextDecoration.ITALIC) + ", " +
+        "clickEvent=" + clickEvent() + ", " +
+        "hoverEvent=" + hoverEvent() + ", " +
+        "insertion=" + insertion() + ")";
   }
 
   @Nonnull

--- a/src/main/java/net/kyori/text/TextComponent.java
+++ b/src/main/java/net/kyori/text/TextComponent.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.text;
 
-import com.google.common.base.MoreObjects;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
@@ -218,9 +217,21 @@ public class TextComponent extends AbstractBuildableComponent<TextComponent, Tex
     return Objects.hash(super.hashCode(), this.content);
   }
 
+  @Nonnull
   @Override
-  protected void populateToString(@Nonnull final MoreObjects.ToStringHelper builder) {
-    builder.add("content", this.content);
+  public String toString() {
+    return "TextComponent(" +
+        "content=" + content() + ", " +
+        "children=" + children() + ", " +
+        "color=" + color() + ", " +
+        "obfuscated=" + decoration(TextDecoration.OBFUSCATED) + ", " +
+        "bold=" + decoration(TextDecoration.BOLD) + ", " +
+        "strikethrough=" + decoration(TextDecoration.STRIKETHROUGH) + ", " +
+        "underlined=" + decoration(TextDecoration.UNDERLINE) + ", " +
+        "italic=" + decoration(TextDecoration.ITALIC) + ", " +
+        "clickEvent=" + clickEvent() + ", " +
+        "hoverEvent=" + hoverEvent() + ", " +
+        "insertion=" + insertion() + ")";
   }
 
   @Nonnull

--- a/src/main/java/net/kyori/text/TranslatableComponent.java
+++ b/src/main/java/net/kyori/text/TranslatableComponent.java
@@ -23,7 +23,6 @@
  */
 package net.kyori.text;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
@@ -273,11 +272,22 @@ public class TranslatableComponent extends AbstractBuildableComponent<Translatab
     return Objects.hash(super.hashCode(), this.key, this.args);
   }
 
+  @Nonnull
   @Override
-  protected void populateToString(@Nonnull final MoreObjects.ToStringHelper builder) {
-    builder
-      .add("key", this.key)
-      .add("args", this.args);
+  public String toString() {
+    return "TranslatableComponent(" +
+        "key=" + key() + ", " +
+        "args=" + args() + ", " +
+        "children=" + children() + ", " +
+        "color=" + color() + ", " +
+        "obfuscated=" + decoration(TextDecoration.OBFUSCATED) + ", " +
+        "bold=" + decoration(TextDecoration.BOLD) + ", " +
+        "strikethrough=" + decoration(TextDecoration.STRIKETHROUGH) + ", " +
+        "underlined=" + decoration(TextDecoration.UNDERLINE) + ", " +
+        "italic=" + decoration(TextDecoration.ITALIC) + ", " +
+        "clickEvent=" + clickEvent() + ", " +
+        "hoverEvent=" + hoverEvent() + ", " +
+        "insertion=" + insertion() + ")";
   }
 
   @Nonnull

--- a/src/main/java/net/kyori/text/event/ClickEvent.java
+++ b/src/main/java/net/kyori/text/event/ClickEvent.java
@@ -24,7 +24,6 @@
 package net.kyori.text.event;
 
 import com.google.common.base.Enums;
-import com.google.common.base.MoreObjects;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Objects;
@@ -100,10 +99,9 @@ public final class ClickEvent {
   @Nonnull
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-      .add("action", this.action)
-      .add("value", this.value)
-      .toString();
+    return "ClickEvent(" +
+        "action=" + this.action + ", " +
+        "value=" + this.value + ")";
   }
 
   /**

--- a/src/main/java/net/kyori/text/event/HoverEvent.java
+++ b/src/main/java/net/kyori/text/event/HoverEvent.java
@@ -24,7 +24,6 @@
 package net.kyori.text.event;
 
 import com.google.common.base.Enums;
-import com.google.common.base.MoreObjects;
 import com.google.gson.annotations.SerializedName;
 import net.kyori.text.Component;
 
@@ -100,10 +99,9 @@ public final class HoverEvent {
   @Nonnull
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-      .add("action", this.action)
-      .add("value", this.value)
-      .toString();
+    return "ClickEvent(" +
+        "action=" + this.action + ", " +
+        "value=" + this.value + ")";
   }
 
   /**


### PR DESCRIPTION
The public plugins I use text in have to be compatible with guava 17.0, since that's what was used in some of the older versions of MC. (sadly, a significant majority still don't run 1.12 😢 )

I've been using a forked version (https://github.com/lucko/text/tree/luck) until now, but would kinda like to stop doing that. 

Not sure if you wanted this in upstream, but I would guess it would be useful for other people looking to use the lib.