### PR TITLE
Add methods to perform modifications to child components recursively

### DIFF
--- a/src/main/java/net/kyori/text/AbstractBuildableComponent.java
+++ b/src/main/java/net/kyori/text/AbstractBuildableComponent.java
@@ -31,7 +31,10 @@ import net.kyori.text.format.TextDecoration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -135,6 +138,69 @@ public abstract class AbstractBuildableComponent<C extends BuildableComponent<C,
     public B append(@Nonnull Iterable<? extends Component> components) {
       if(this.children == EMPTY_COMPONENT_LIST) this.children = new ArrayList<>();
       Iterables.addAll(this.children, components);
+      return (B) this;
+    }
+
+    @Override
+    public B applyDeep(@Nonnull final Consumer<Builder<?, ?>> action) {
+      this.apply(action);
+      if(this.children == EMPTY_COMPONENT_LIST) {
+        return (B) this;
+      }
+      final ListIterator<Component> it = this.children.listIterator();
+      while(it.hasNext()) {
+        final Component child = it.next();
+        if(!(child instanceof BuildableComponent)) {
+          continue;
+        }
+        final Builder<?, ?> childBuilder = ((BuildableComponent) child).toBuilder();
+        childBuilder.applyDeep(action);
+        it.set(childBuilder.build());
+      }
+      return (B) this;
+    }
+
+    @Nonnull
+    @Override
+    public B mapChildren(@Nonnull Function<BuildableComponent<? ,?>, BuildableComponent<? ,?>> function) {
+      if(this.children == EMPTY_COMPONENT_LIST) {
+        return (B) this;
+      }
+      final ListIterator<Component> it = this.children.listIterator();
+      while(it.hasNext()) {
+        final Component child = it.next();
+        if(!(child instanceof BuildableComponent)) {
+          continue;
+        }
+        final BuildableComponent mappedChild = function.apply((BuildableComponent) child);
+        if(child == mappedChild) continue;
+        it.set(mappedChild);
+      }
+      return (B) this;
+    }
+
+    @Nonnull
+    @Override
+    public B mapChildrenDeep(@Nonnull Function<BuildableComponent<? ,?>, BuildableComponent<? ,?>> function) {
+      if(this.children == EMPTY_COMPONENT_LIST) {
+        return (B) this;
+      }
+      final ListIterator<Component> it = this.children.listIterator();
+      while(it.hasNext()) {
+        final Component child = it.next();
+        if(!(child instanceof BuildableComponent)) {
+          continue;
+        }
+        final BuildableComponent mappedChild = function.apply((BuildableComponent) child);
+        if(mappedChild.children().isEmpty()) {
+          if(child == mappedChild) continue;
+          it.set(mappedChild);
+        } else {
+          final Builder<?, ?> builder = mappedChild.toBuilder();
+          builder.mapChildrenDeep(function);
+          it.set(builder.build());
+        }
+      }
       return (B) this;
     }
 

--- a/src/main/java/net/kyori/text/BuildableComponent.java
+++ b/src/main/java/net/kyori/text/BuildableComponent.java
@@ -28,6 +28,9 @@ import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
 import net.kyori.text.format.TextDecoration;
 
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -72,6 +75,45 @@ public interface BuildableComponent<C extends BuildableComponent<C, B>, B extend
      */
     @Nonnull
     B append(@Nonnull final Iterable<? extends Component> components);
+
+    /**
+     * Applies an action to this builder.
+     *
+     * @param action the action
+     * @return this builder
+     */
+    default B apply(@Nonnull final Consumer<Builder<? ,?>> action) {
+      action.accept(this);
+      return (B) this;
+    }
+
+    /**
+     * Applies an action to this component and all child components if they are
+     * an instance of {@link BuildableComponent}.
+     *
+     * @param action the action
+     * @return this builder
+     */
+    B applyDeep(@Nonnull final Consumer<Builder<?, ?>> action);
+
+    /**
+     * Replaces each child of this component with the resultant component from the function.
+     *
+     * @param function the mapping function
+     * @return this builder
+     */
+    @Nonnull
+    B mapChildren(@Nonnull final Function<BuildableComponent<?, ?>, BuildableComponent<?, ?>> function);
+
+    /**
+     * Replaces each child and sub-child of this component with the resultant
+     * component of the function.
+     *
+     * @param function the mapping function
+     * @return this builder
+     */
+    @Nonnull
+    B mapChildrenDeep(@Nonnull final Function<BuildableComponent<?, ?>, BuildableComponent<?, ?>> function);
 
     /**
      * Sets the color of this component.


### PR DESCRIPTION
Allows you to do stuff like this.

```java
BuildableComponent someComponent = LegacyComponent.from("&cHello &bworld.", '&');

BuildableComponent.Builder<?, ?> builder = someComponent.toBuilder();

HoverEvent hoverEvent = new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.of("Hi there!"));
builder.applyDeep(b -> b.hoverEvent(hoverEvent));

someComponent = builder.build();
```

In this case, take a whole component and applying a HoverEvent to everything, including all children. This is especially useful for modifying components obtained from other sources, or applying hover/click events to legacy text.

Also (perhaps) useful, is the ability to completely remap an existing component. For example, find a specific KeybindComponent, and replace it with a TextComponent.

```java
// some magic component
BuildableComponent someComponent = null;

BuildableComponent.Builder<?, ?> builder = someComponent.toBuilder();

// "Press W"  ...  more like "Press the forward key"
// remaps the 'key_key.forward' keybind component to a text component, if there is one present somewhere
builder.mapChildrenDeep(c -> {
    if (c instanceof KeybindComponent) {
        KeybindComponent keybind = (KeybindComponent) c;
        if (keybind.keybind().equals("key_key.forward")) {
            // uhh, no!
            return TextComponent.of("the forward key");
        }
    }
    return c;
});

someComponent = builder.build();
```

I wasn't too sure about how it should be implemented, not sure what you'll think of it... It was [a bit easier when Components were mutable](https://github.com/lucko/text/commit/e3d62b699f2739147fcfe339c2d02fc23205d66b). :wink:

