### PR TITLE
Fix deserialization of legacy text

### DIFF
--- a/src/main/java/net/kyori/text/LegacyComponent.java
+++ b/src/main/java/net/kyori/text/LegacyComponent.java
@@ -63,7 +63,7 @@ public final class LegacyComponent {
       return TextComponent.of(input);
     }
 
-    final List<TextComponent.Builder> parts = new ArrayList<>();
+    final List<TextComponent> parts = new ArrayList<>();
 
     TextComponent.Builder current = null;
     boolean reset = false;
@@ -76,7 +76,7 @@ public final class LegacyComponent {
         if(from != pos) {
           if(current != null) {
             if(reset) {
-              parts.add(current);
+              parts.add(current.build());
               reset = false;
               current = TextComponent.builder("");
             } else {
@@ -99,21 +99,11 @@ public final class LegacyComponent {
     } while(next != -1);
 
     if(current != null) {
-      parts.add(current);
+      parts.add(current.build());
     }
 
     Collections.reverse(parts);
-    switch(parts.size()) {
-      case 0:
-        return TextComponent.of(pos > 0 ? input.substring(0, pos) : "");
-      case 1:
-        return parts.get(0).build();
-      case 2:
-      default:
-        return parts.get(0)
-          .append(parts.subList(1, parts.size()).stream().map(TextComponent.Builder::build).collect(Collectors.toList()))
-          .build();
-    }
+    return TextComponent.builder(pos > 0 ? input.substring(0, pos) : "").append(parts).build();
   }
 
   private static boolean applyFormat(@Nonnull final TextComponent.Builder builder, @Nonnull final TextFormat format) {

--- a/src/test/java/net/kyori/text/LegacyComponentTest.java
+++ b/src/test/java/net/kyori/text/LegacyComponentTest.java
@@ -24,6 +24,8 @@
 package net.kyori.text;
 
 import net.kyori.text.format.TextColor;
+import net.kyori.text.format.TextDecoration;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -37,7 +39,11 @@ public class LegacyComponentTest {
 
   @Test
   public void testFromColor() {
-    assertEquals(TextComponent.of("foo").color(TextColor.GREEN), LegacyComponent.from(LegacyComponent.CHARACTER + "afoo"));
-    assertEquals(TextComponent.of("foo").color(TextColor.GREEN).append(TextComponent.of("bar").color(TextColor.BLUE)), LegacyComponent.from(LegacyComponent.CHARACTER + "afoo" + LegacyComponent.CHARACTER + "9bar"));
+    TextComponent component = TextComponent.builder("")
+      .append(TextComponent.of("foo").color(TextColor.GREEN).decoration(TextDecoration.BOLD, TextDecoration.State.TRUE))
+      .append(TextComponent.of("bar").color(TextColor.BLUE))
+      .build();
+
+    assertEquals(component, LegacyComponent.from("&a&lfoo&9bar", '&'));
   }
 }


### PR DESCRIPTION
Fixes all components inheriting color/style from the first component in the chain.

For example, currently:
```
&3> &rpms &7- &rfalse
```

is parsed to
![](https://i.imgur.com/MoHkFFX.png)